### PR TITLE
Allow TOC in any .md file

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -23,4 +23,4 @@
     args: [-i]
     language: node
     additional_dependencies: [markdown-toc]
-    files: ^README.md$
+    files: .*\.md$


### PR DESCRIPTION
Doesn't make much sense to restrict this just to README, isn't it?